### PR TITLE
Fix: display first Text command

### DIFF
--- a/Assets/Scenes/TitleScene.unity
+++ b/Assets/Scenes/TitleScene.unity
@@ -268,6 +268,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8992101991809943519, guid: c216516ec832e0c43a20b6aa56efc02b, type: 3}
+      propertyPath: soundSetting.masterVolume
+      value: 0.056
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scripts/Story_Scenario/TextWindows.cs
+++ b/Assets/Scripts/Story_Scenario/TextWindows.cs
@@ -22,11 +22,6 @@ public class TextWindows : SceneSingleton<TextWindows>
         SkipIcon.SetActive(false);
     }
 
-    private void Update()
-    {
-        ShouldProcessInput();
-    }
-
     public void Pause()
     {
         isPaused = !isPaused;
@@ -48,19 +43,22 @@ public class TextWindows : SceneSingleton<TextWindows>
         int skipThreshold // 表示文字数のスキップ許可閾値（%）
     )
     {
-        // nameText.text = name;
-        bodyText.text = body;
+        SpeechBubble.SetActive(true);
+        // SkipIcon.SetActive(false);
+
+
+        // nameText.SetText(name);
+        bodyText.SetText(body);
         bodyText.maxVisibleCharacters = 0;
         bodyText.ForceMeshUpdate();
         // nameText.ForceMeshUpdate();
 
-        int totalLength = bodyText.GetParsedText().Length;
+        // int totalLength = bodyText.GetParsedText().Length;
+        int totalLength = bodyText.textInfo.characterCount;
+
         int skipLimit = Mathf.CeilToInt(totalLength * (skipThreshold / 100f));
         skipRequested = false;
         int visibleCount = 0;
-
-        SpeechBubble.SetActive(true);
-        // SkipIcon.SetActive(false);
 
         while (visibleCount < totalLength)
         {


### PR DESCRIPTION
Ensure the first Text command is properly rendered by activating the text window before setting maxVisibleCharacters and forcing a mesh update. This resolves the issue where the initial dialogue never appeared.

SetActiveの順序が主な原因だったと推測される