### PR TITLE
fix: カーソルのサイズの変更

### DIFF
--- a/Assets/Images/cursor_3.png.meta
+++ b/Assets/Images/cursor_3.png.meta
@@ -111,14 +111,14 @@ TextureImporter:
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 4
     buildTarget: WebGL
-    maxTextureSize: 2048
+    maxTextureSize: 32
     resizeAlgorithm: 0
     textureFormat: 4
     textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 0
+    overridden: 1
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0

--- a/Assets/Scripts/System/VersionDisplay.cs
+++ b/Assets/Scripts/System/VersionDisplay.cs
@@ -1,9 +1,8 @@
 ﻿using UnityEngine;
-using TMPro; // TextMeshProを使用する場合に必要です
+using TMPro;
 
 public class VersionDisplay : MonoBehaviour
 {
-    // UnityエディタからTextMeshProUGUIコンポーネントをここにドラッグ＆ドロップしてください
     public TextMeshProUGUI versionText;
 
     void Start()
@@ -25,29 +24,27 @@ public class VersionDisplay : MonoBehaviour
         }
         else
         {
-            // 割り当てられていない場合は、デバッグログに表示します
             Debug.LogWarning("Version Text (TextMeshProUGUI) is not assigned. Displaying in Debug.Log: " + displayString);
             Debug.Log(displayString);
         }
     }
 
-    // 各プラットフォームに対応する短い文字列を返します
     string GetPlatformString()
     {
         switch (Application.platform)
         {
             case RuntimePlatform.WindowsPlayer:
             case RuntimePlatform.WindowsEditor:
-                return "win";
+                return "Windows";
             case RuntimePlatform.WebGLPlayer:
-                return "webgl";
+                return "WebGL";
             case RuntimePlatform.OSXPlayer:
             case RuntimePlatform.OSXEditor:
-                return "mac";
+                return "macOS";
             case RuntimePlatform.Android:
-                return "android";
+                return "Android";
             case RuntimePlatform.IPhonePlayer:
-                return "ios";
+                return "iOS";
             case RuntimePlatform.LinuxPlayer:
             case RuntimePlatform.LinuxEditor:
                 return "linux";


### PR DESCRIPTION
Windowsビルドでは同じバグは見えなかった

そのため、webglの時だけカーソル素材の最大サイズを32×32にした